### PR TITLE
initial support for derive with generic types

### DIFF
--- a/base/src/decode/mod.rs
+++ b/base/src/decode/mod.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 use crate::Error;
 
 mod owned;
-pub use owned::DecodeOwned;
+pub use owned::{DecodeOwned};
 
 mod ext;
 pub use ext::{DecodeExt, DecodeIter};

--- a/base/src/error.rs
+++ b/base/src/error.rs
@@ -1,5 +1,7 @@
 //! Basic encdec [`Error`] type
 
+use core::convert::Infallible;
+
 /// Basic encode/decode error type
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
@@ -8,4 +10,10 @@ pub enum Error {
     Length,
     /// Invalid UTF8 in string
     Utf8,
+}
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -5,6 +5,8 @@
 // TODO: remove when [rust-lang:89379](https://github.com/rust-lang/rust/issues/89379)
 #![cfg_attr(feature = "nightly", feature(array_try_from_fn))]
 
+#![cfg_attr(feature = "nightly", feature(associated_type_defaults))]
+
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,29 +1,26 @@
 //! Common traits and helper macros for binary encoding and decoding.
-//! 
+//!
 //! This crate provides common [`Encode`] and [`Decode`] traits for describing binary encode/decode-able objects, as well as [`#[derive(Encode)]`][encdec_macros::Encode] and [`#[derive(Decode)]`][encdec_macros::Decode] macros to reduce boilerplate when propagating these and little-endian implementations for primitive types.
 //! For more implementation see the module-level documentation.
-//! 
+//!
 //! This is intended to provide a reusable base for implementing binary encodable objects to match a particular protocol or specification (and mitigate embedded `pub trait (Encode|Decode) {..}` bankruptcy)
-//! 
+//!
 //! If you don't need to control the encoded layout directly you might like to look at [serde](https://crates.io/crates/serde), with [postcard](https://crates.io/crates/postcard) for efficient binary encoding between rust components.
 //! If you're creating a new protocol for cross-language use you may wish to consider creating a specification using [protocol buffers](https://developers.google.com/protocol-buffers) and [prost](https://crates.io/crates/prost).
-//! 
-
+//!
 
 #![no_std]
 
 // Re-export base traits
-pub use encdec_base::{
-    EncDec, Error,
-};
+pub use encdec_base::{EncDec, Error};
 
 // Re-export traits from modules here
+pub use crate::decode::{Decode, DecodeExt, DecodeOwned};
 pub use crate::encode::{Encode, EncodeExt};
-pub use crate::decode::{Decode, DecodeOwned, DecodeExt};
 
 pub mod encode {
     //! [`Encode`] traits and helper macros
-    //! 
+    //!
     //! ## Example
     //! ```
     //! # use encdec::{Encode, Decode, Error};
@@ -33,16 +30,16 @@ pub mod encode {
     //!     b: u16,
     //!     c: [u8; 3],
     //! }
-    //! 
+    //!
     //! impl Encode for Something {
     //!     type Error = Error;
-    //! 
+    //!
     //!     /// Fetch encoded length for an encodable object    
     //!     fn encode_len(&self) -> Result<usize, Self::Error> {
     //!         Ok(1 + 2 + 3)
     //!     }
-    //! 
-    //!    /// Encode object to the provided buffer, 
+    //!
+    //!    /// Encode object to the provided buffer,
     //!    /// returning the encoded length on success
     //!    fn encode(&self, buff: &mut [u8]) -> Result<usize, Self::Error> {
     //!        let mut index = 0;
@@ -63,12 +60,12 @@ pub mod encode {
 
     pub use encdec_base::encode::*;
 
-    pub use crate::derive::{Encode};
+    pub use crate::derive::Encode;
 }
 
 pub mod decode {
     //! [`Decode`] traits and helper macros
-    //! 
+    //!
     //! ## Example
     //! ```
     //! # use encdec::{Encode, DecodeOwned, Error};
@@ -78,12 +75,12 @@ pub mod decode {
     //!     b: u16,
     //!     c: [u8; 3],
     //! }
-    //! 
+    //!
     //! /// [`DecodeOwned`] implementation for self-contained types.
     //! impl DecodeOwned for SomethingOwned {
     //!     type Output = Self;
     //!     type Error = Error;
-    //! 
+    //!
     //!    /// Decode object from provided buffer, returning object and decoded
     //!    /// length on success
     //!    fn decode_owned(buff: &[u8]) -> Result<(Self::Output, usize), Self::Error> {
@@ -91,19 +88,19 @@ pub mod decode {
     //!
     //!         let a = buff[0];
     //!         index += 1;
-    //! 
+    //!
     //!         let b = buff[1] as u16 | (buff[2] as u16) << 8;
     //!         index += 2;
-    //! 
+    //!
     //!         let mut c = [0u8; 3];
     //!         c.copy_from_slice(&buff[3..][..3]);
     //!         index += 3;
-    //! 
+    //!
     //!         Ok((Self{a, b, c}, index))
     //!    }
     //! }
     //! ```
-    //! 
+    //!
     //! ```
     //! # use encdec::{Encode, Decode, Error};
     //! #[derive(Debug, PartialEq)]
@@ -112,13 +109,13 @@ pub mod decode {
     //!     l: u16,
     //!     c: &'a [u8],
     //! }
-    //! 
-    //! /// Base [`Decode`] implementation, lifetime support for views 
+    //!
+    //! /// Base [`Decode`] implementation, lifetime support for views
     //! /// into borrowed buffers. If you don't need this, see [`DecodeOwned`].
     //! impl <'a>Decode<'a> for SomethingBorrowed<'a> {
     //!     type Output = SomethingBorrowed<'a>;
     //!     type Error = Error;
-    //! 
+    //!
     //!    /// Decode object from provided buffer, returning object and decoded
     //!    /// length on success
     //!    fn decode(buff: &'a [u8]) -> Result<(Self::Output, usize), Self::Error> {
@@ -126,13 +123,13 @@ pub mod decode {
     //!
     //!         let a = buff[0];
     //!         index += 1;
-    //! 
+    //!
     //!         // using `l` as the length of `c`
     //!         let l = buff[1] as u16 | (buff[2] as u16) << 8;
     //!         index += 2;
-    //! 
-    //!         let c = &buff[index..][..l as usize]; 
-    //! 
+    //!
+    //!         let c = &buff[index..][..l as usize];
+    //!
     //!         Ok((Self{a, l, c}, index))
     //!    }
     //! }
@@ -146,14 +143,14 @@ pub mod decode {
 // Re-export macros
 pub mod derive {
     //! Macros for deriving primitive [`Decode`] and [`Encode`] implementations on types containing decodable/encodable fields.
-    //! 
+    //!
     //! These derivations are _intended_ to be stable, **however**, if you're using these macros to implement a specific protocol you _really should_ write tests to ensure the binary encoding matches your expectations.
-    //! 
+    //!
     //! ## Example
-    //! 
+    //!
     //! Derive macros provide a simple way to implement [`Encode`] and [`Decode`] for objects with (enc|dec)odable fields by (de)serializing each field in order.
     //! For detail on derived implementations see the [Encode][encdec_macros::Encode] and [Decode][encdec_macros::Decode] macros.
-    //! 
+    //!
     //! ```
     //! # use encdec::{Encode, Decode, Error};
     //! #[derive(Debug, PartialEq, Encode, Decode)]
@@ -163,40 +160,39 @@ pub mod derive {
     //!     c: u8,
     //! }
     //! # let mut buff = [0u8; 16];
-    //! 
+    //!
     //! let a1 = Something{ a: 0x10, b: 0xabcd, c: 0x11 };
     //! let n1 = a1.encode(&mut buff[..]).unwrap();
-    //! 
+    //!
     //! // Encoded data is little endian, ordered by struct field
     //! assert_eq!(&buff[..n1], &[0x10, 0xcd, 0xab, 0x11]);
     //!
     //! let (a2, n2) = Something::decode(&buff[..n1]).unwrap();
     //! assert_eq!(a1, a2);
     //! ```
-    //! 
-    //! 
+    //!
+    //!
     //! ## Customisation
-    //! 
+    //!
     //! ### Error Types
-    //! 
-    //! Derived error types may be overridden with a struct level attribute 
-    //! `#[encdec(error = "E")]` where `E` is a user error type implementing 
+    //!
+    //! Derived error types may be overridden with a struct level attribute
+    //! `#[encdec(error = "E")]` where `E` is a user error type implementing
     //! `From<encdec::Error>`
-    //! 
+    //!
     //! ### Encode/Decode methods
-    //! 
+    //!
     //! Field encode/decode methods may be overridden using a field level attribute
     //! `#[encdec(with = "M")]` on a field of type `T`, where `M` is a module providing:
     //! - `fn enc(&T, &mut [u8]) -> Result<usize, E>`
     //! - `fn enc_len(&T) -> Result<usize, E>`
     //! - `fn dec(&[u8]) -> Result<(T, usize), E>`
-    //! 
-    //! 
+    //!
+    //!
     //! Individual methods may be overridden if required using `#[encdec(enc = "..", enc_len = "..", dec = "..")]` with the same type signatures / constraints as above.
-    
-    pub use encdec_macros::{Encode, Decode, DecodeOwned};
-}
 
+    pub use encdec_macros::{Decode, DecodeOwned, Encode};
+}
 
 // Re-export helpers
 pub mod helpers {

--- a/core/tests/primitives.rs
+++ b/core/tests/primitives.rs
@@ -1,7 +1,6 @@
-
 use rand::random;
 
-use encdec::{helpers::test_encode_decode};
+use encdec::helpers::test_encode_decode;
 
 #[test]
 fn encode_decode_u8() {

--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -104,8 +104,7 @@ pub fn derive_decode_impl(input: TokenStream, owned: bool) -> TokenStream {
     for g in &generic_types {
         // Look for types with Decode bounds
         let a = g.bounds.iter().find_map(|v| {
-            println!("t: {:?}", v);
-            
+
             // Find trait bounds
             let t = match v {            
                 TypeParamBound::Trait(t) => t,

--- a/macros/src/decode.rs
+++ b/macros/src/decode.rs
@@ -3,7 +3,7 @@
 use proc_macro::{TokenStream};
 
 use quote::{quote};
-use syn::{parse_macro_input, DeriveInput, Data, Fields, Ident, Lifetime};
+use syn::{parse_macro_input, DeriveInput, Data, Fields, Ident, Lifetime, TypeParamBound, WhereClause, parse::Parse};
 
 use crate::attrs::{FieldAttrs, StructAttrs};
 
@@ -28,7 +28,7 @@ pub fn derive_decode_impl(input: TokenStream, owned: bool) -> TokenStream {
     let mut fields = quote!{};
 
     // Fetch bounds for generics
-    let (_impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
 
     s.fields.iter().enumerate().for_each(|(i, f)| {
         let ty = &f.ty;
@@ -57,6 +57,7 @@ pub fn derive_decode_impl(input: TokenStream, owned: bool) -> TokenStream {
             }),
             (_, _, None) => parsers.extend(quote!{
                 let (#id, n) = <#ty>::decode(&buff[_index..])?;
+                let #id = #id.into();
                 _index += n;
             }),
         }
@@ -70,11 +71,14 @@ pub fn derive_decode_impl(input: TokenStream, owned: bool) -> TokenStream {
         Fields::Unit => quote!(Self{#fields}),
     };
 
-    let lts: Vec<_> = generics.lifetimes()
+    let lifetimes: Vec<_> = generics.lifetimes()
         .map(|v| Lifetime::from(v.lifetime.clone()) )
         .collect();
 
-    let gs: Vec<_> = generics.const_params()
+    
+    let generic_types: Vec<_> = generics.type_params().collect();
+
+    let const_params: Vec<_> = generics.const_params()
         .map(|v| {
             let mut v = v.clone();
             v.eq_token = None;
@@ -88,9 +92,68 @@ pub fn derive_decode_impl(input: TokenStream, owned: bool) -> TokenStream {
         None => quote!(::encdec::Error),
     };
 
+    // Extract where bounds
+    let mut where_bounds = match &generics.where_clause {
+        Some(v) => {
+            v.predicates.iter().map(|v| quote!(#v) ).collect()
+        },
+        _ => vec![],
+    };
+
+    // Add where bounds for Decode types
+    for g in &generic_types {
+        // Look for types with Decode bounds
+        let a = g.bounds.iter().find_map(|v| {
+            println!("t: {:?}", v);
+            
+            // Find trait bounds
+            let t = match v {            
+                TypeParamBound::Trait(t) => t,
+                _ => return None,
+            };
+
+            // Match decode bounds
+            let s = match t.path.segments.first() {
+                Some(v) if v.ident == "Decode" => v,
+                Some(v) if v.ident == "DecodeOwned" => v,
+                _ => return None,
+            };
+
+            Some(v)
+        });
+
+        // Skip non-Decode types (probably not possible?)
+        let a = match a {
+            Some(v) => v,
+            None => continue,
+        };
+
+        // Fetch type
+        let t = &g.ident;
+
+        // Append where clause
+        let w = quote!(
+            #t: From<<#t as #a>::Output>,
+            #err: From<<#t as #a>::Error>,
+        );
+
+        where_bounds.push(w);
+    }
+
+    // Build where clause
+    let mut where_clause = None;
+    if where_bounds.len() > 0 {
+        where_clause = Some(quote! {
+            where
+                #(#where_bounds),*
+        });
+    }
+
+    //panic!("bounds: {}", TokenStream::from(where_clause.unwrap()));
+
     match owned {
         false => quote! {
-            impl <'dec: #(#lts)+*, #(#lts),* #(#gs),*> ::encdec::Decode<'dec> for #ident #ty_generics #where_clause {
+            impl <'dec: #(#lifetimes)+*, #(#lifetimes),* #(#generic_types),* #(#const_params),*> ::encdec::Decode<'dec> for #ident #ty_generics #where_clause {
                 type Output = Self;
                 type Error = #err;
                 
@@ -106,7 +169,7 @@ pub fn derive_decode_impl(input: TokenStream, owned: bool) -> TokenStream {
             }
         },
         true => quote! {
-            impl <#(#lts),* #(#gs),*> ::encdec::DecodeOwned for #ident #ty_generics #where_clause {
+            impl <#(#lifetimes),* #(#generic_types),* #(#const_params),*> ::encdec::DecodeOwned for #ident #ty_generics #where_clause {
                 type Output = Self;
                 type Error = #err;
                 


### PR DESCRIPTION
towards #4, first pass of generic type support for derive macro. adds parsing for generic types in structures and injects where bounds in derived implementations.

```rust
struct SomeGeneric<M: Encode + DecodeOwned + Debug> {
    m: M,
}
```

becomes:
```rust

impl<M: Encode + DecodeOwned + Debug> ::encdec::Encode for SomeGeneric<M>
where
    ::encdec::Error: From<<M as Encode>::Error>,
{ ... }

impl<'dec, M: Encode + DecodeOwned + Debug> ::encdec::Decode<'dec> for SomeGeneric<M>
where
    M: From<<M as DecodeOwned>::Output>,
    ::encdec::Error: From<<M as DecodeOwned>::Error>,
{ ... }
```